### PR TITLE
Redirecting to Correct Unit Show Page from Product View

### DIFF
--- a/resources/views/products/show.blade.php
+++ b/resources/views/products/show.blade.php
@@ -69,7 +69,7 @@
                                     <tr>
                                         <td>Unit</td>
                                         <td>
-                                            <a href="{{ route('categories.show', $product->unit) }}" class="badge bg-blue-lt">
+                                            <a href="{{ route('units.show', $product->unit) }}" class="badge bg-blue-lt">
                                                 {{ $product->unit->short_code }}
                                             </a>
                                         </td>


### PR DESCRIPTION
Fixed an issue where clicking on the unit from the product page incorrectly redirected to the categories page. It now correctly navigates to the unit's show page.